### PR TITLE
Refactor landed cost handling for overseas warehouses

### DIFF
--- a/app/controllers/admin/Purchases.php
+++ b/app/controllers/admin/Purchases.php
@@ -479,7 +479,7 @@ class Purchases extends MY_Controller
 
                     $landed_cost = 0;
                     $landed_per_unit = 0;
-                    if ($is_po_invoice && $this->site->canAccessOverseasWarehouse()) {
+                    if ($is_po_invoice && $this->site->canUseLandedCostForWarehouse($warehouse_id)) {
                         $landed_cost = $this->sma->formatDecimal(isset($_POST['landed_cost'][$r]) ? $_POST['landed_cost'][$r] : 0, 5);
                         if ($landed_cost < 0) {
                             $landed_cost = 0;
@@ -670,12 +670,12 @@ class Purchases extends MY_Controller
         if ($this->form_validation->run() == true && !empty($products)) {
             if ($this->input->post('action') == 'create_invoice') {
                 $total_landed_cost_check = 0;
-                if ($this->site->canAccessOverseasWarehouse()) {
+                if ($this->site->canUseLandedCostForWarehouse($warehouse_id)) {
                     foreach ($products as $p) {
                         $total_landed_cost_check += (float) ($p['landed_cost'] ?? 0);
                     }
                 }
-                if ($total_landed_cost_check > 0 && !$this->getLandedCostLedgerId()) {
+                if ($total_landed_cost_check > 0 && !$this->site->getLandedCostLedgerId()) {
                     $this->session->set_flashdata('error', lang('landed_cost_ledger_required'));
                     $po_id = (int) $this->input->post('po_id');
                     admin_redirect('purchases/add?action=create_invoice&po_number=' . base64_encode($po_id));
@@ -840,8 +840,15 @@ class Purchases extends MY_Controller
             $this->data['categories'] = $this->site->getAllCategories();
             $this->data['tax_rates'] = $this->site->getAllTaxRates();
             $this->data['warehouses'] = $this->site->getAllWarehouses();
-            $this->data['canUseLandedCost'] = $this->site->canAccessOverseasWarehouse() && (bool) $this->getLandedCostLedgerId();
-            $this->data['landed_cost_ledger_missing'] = $this->site->canAccessOverseasWarehouse() && !$this->getLandedCostLedgerId();
+            $po_warehouse_id = (!empty($this->data['pr_data']->warehouse_id))
+                ? (int) $this->data['pr_data']->warehouse_id
+                : 0;
+            $this->data['canUseLandedCost'] = $po_warehouse_id
+                && $this->site->canUseLandedCostForWarehouse($po_warehouse_id);
+            $this->data['landed_cost_ledger_missing'] = $po_warehouse_id
+                && $this->site->isOverseasWarehouse($po_warehouse_id)
+                && $this->site->canAccessOverseasWarehouse()
+                && !$this->site->getLandedCostLedgerId();
             $this->data['ponumber'] = ''; //$this->site->getReference('po');
             $this->load->helper('string');
             $value = random_string('alnum', 20);
@@ -2029,17 +2036,6 @@ class Purchases extends MY_Controller
         echo $this->datatables->generate();
     }
 
-    private function getLandedCostLedgerId()
-    {
-        static $ledger_id = null;
-        if ($ledger_id !== null) {
-            return $ledger_id;
-        }
-        $row = $this->db->get_where('accounts_ledgers', ['code' => '1130100004'], 1)->row();
-        $ledger_id = $row ? (int) $row->id : false;
-        return $ledger_id;
-    }
-
     public function convert_purchse_invoice($pid)
     {
         if ($this->purchases_model->puchaseToInvoice($pid)) {
@@ -2054,8 +2050,10 @@ class Purchases extends MY_Controller
             $warehouse_ledgers = $this->site->getWarehouseByID($warehouse_id);
 
             $total_landed_cost = 0;
-            foreach ($inv_items as $item) {
-                $total_landed_cost += (float) ($item->landed_cost ?? 0);
+            if ($this->site->isOverseasWarehouse($warehouse_id)) {
+                foreach ($inv_items as $item) {
+                    $total_landed_cost += (float) ($item->landed_cost ?? 0);
+                }
             }
             $total_landed_cost = $this->sma->formatDecimal($total_landed_cost, 4);
 
@@ -2122,8 +2120,8 @@ class Purchases extends MY_Controller
                 )
             );
 
-            if ($total_landed_cost > 0) {
-                $landed_cost_ledger_id = $this->getLandedCostLedgerId();
+            if ($total_landed_cost > 0 && $this->site->isOverseasWarehouse($warehouse_id)) {
+                $landed_cost_ledger_id = $this->site->getLandedCostLedgerId();
                 if ($landed_cost_ledger_id) {
                     $entryitemdata[] = array(
                         'Entryitem' => array(
@@ -2131,7 +2129,7 @@ class Purchases extends MY_Controller
                             'dc' => 'C',
                             'ledger_id' => $landed_cost_ledger_id,
                             'amount' => $total_landed_cost,
-                            'narration' => 'Goods in Transit (1130100004) - landed cost'
+                            'narration' => 'Goods in Transit - landed cost'
                         )
                     );
                 }

--- a/app/controllers/admin/System_settings.php
+++ b/app/controllers/admin/System_settings.php
@@ -2219,6 +2219,11 @@ class system_settings extends MY_Controller
                     'country'        => $this->input->post('country'),
                     'inventory_ledger'    => $this->input->post('inventory_ledger'),
                 ];
+                if (!empty($wh_details->is_overseas)) {
+                    $data['sales_ledger'] = $this->input->post('sales_ledger');
+                    $data['cogs_ledger'] = $this->input->post('cogs_ledger');
+                    $data['landed_cost_ledger'] = $this->input->post('landed_cost_ledger');
+                }
             }else if($this->input->post('type') == 'pharmacy'){
                 $data = ['code'      => $this->input->post('code'),
                     'name'           => $this->input->post('name'),

--- a/app/language/english/admin/purchases_lang.php
+++ b/app/language/english/admin/purchases_lang.php
@@ -123,4 +123,5 @@ $lang['update_supplier_email']               = 'Please update supplier email add
 $lang['product_x_found']                     = 'System can not find the product %s';
 $lang['landed_cost']                         = 'Landed Cost';
 $lang['landed_cost_per_unit']                = 'Landed Cost / Unit';
-$lang['landed_cost_ledger_required']         = 'Goods in Transit ledger (1130100004) was not found in Chart of Accounts. Cannot post landed cost.';
+$lang['landed_cost_ledger_required']         = 'Goods in Transit ledger is not configured on the Overseas Warehouse. Cannot post landed cost.';
+$lang['landed_cost_git_ledger']              = 'Goods in Transit Account (Landed Cost)';

--- a/app/language/english/admin/settings_lang.php
+++ b/app/language/english/admin/settings_lang.php
@@ -157,6 +157,7 @@ $lang['map_image']                                                   = 'Map Imag
 $lang['warehouse_map']                                               = 'Warehouse Map';
 $lang['warehouse_added']                                             = 'Warehouse successfully added';
 $lang['warehouse_updated']                                           = 'Warehouse successfully updated';
+$lang['landed_cost_git_ledger']                                      = 'Goods in Transit Account (Landed Cost)';
 $lang['warehouse_deleted']                                           = 'Warehouse successfully deleted';
 $lang['warehouses_deleted']                                          = 'Warehouse successfully deleted';
 $lang['mail_message']                                                = 'Mail Message';

--- a/app/models/Site.php
+++ b/app/models/Site.php
@@ -1636,6 +1636,44 @@ public function logVisitor() {
         return false;
     }
 
+    /**
+     * Goods in Transit ledger for overseas landed cost.
+     * Uses overseas warehouse landed_cost_ledger (ID).
+     * Falls back to the goods-in-transit warehouse inventory_ledger for legacy setups.
+     */
+    public function getLandedCostLedgerId()
+    {
+        static $ledger_id = null;
+        if ($ledger_id !== null) {
+            return $ledger_id ?: false;
+        }
+
+        $osw_id = $this->getOverseasWarehouseId();
+        if ($osw_id) {
+            $osw = $this->getWarehouseByID($osw_id);
+            if ($osw && !empty($osw->landed_cost_ledger)) {
+                $ledger_id = (int) $osw->landed_cost_ledger;
+                return $ledger_id;
+            }
+        }
+
+        $git_wh = $this->getGoodsTrasitWareHouse();
+        $ledger_id = ($git_wh && !empty($git_wh->inventory_ledger))
+            ? (int) $git_wh->inventory_ledger
+            : 0;
+
+        return $ledger_id ?: false;
+    }
+
+    /** Landed cost is only for purchase orders on the overseas warehouse. */
+    public function canUseLandedCostForWarehouse($warehouse_id)
+    {
+        if (!$this->isOverseasWarehouse($warehouse_id)) {
+            return false;
+        }
+        return $this->canAccessOverseasWarehouse() && (bool) $this->getLandedCostLedgerId();
+    }
+
     public function getWarehouseProduct($warehouse_id, $product_id)
     {
         $q = $this->db->get_where('warehouses_products', ['product_id' => $product_id, 'warehouse_id' => $warehouse_id], 1);

--- a/themes/blue/admin/views/settings/edit_warehouse.php
+++ b/themes/blue/admin/views/settings/edit_warehouse.php
@@ -69,6 +69,27 @@
                 ?>
             </div>
 
+            <?php if (!empty($warehouse->is_overseas)) { ?>
+            <div class="form-group overseas_ledgers_group">
+                <?= lang('Sales Account', 'sales_ledger'); ?>
+                <?php
+                echo form_dropdown('sales_ledger', $LO, $warehouse->sales_ledger, 'id="sales_ledger" class="ledger-dropdown form-control" required="required"', $DIS);
+                ?>
+            </div>
+            <div class="form-group overseas_ledgers_group">
+                <?= lang('Cogs Account', 'cogs_ledger'); ?>
+                <?php
+                echo form_dropdown('cogs_ledger', $LO, $warehouse->cogs_ledger, 'id="cogs_ledger" class="ledger-dropdown form-control" required="required"', $DIS);
+                ?>
+            </div>
+            <div class="form-group overseas_ledgers_group">
+                <?= lang('landed_cost_git_ledger', 'landed_cost_ledger'); ?>
+                <?php
+                echo form_dropdown('landed_cost_ledger', $LO, $warehouse->landed_cost_ledger ?? 0, 'id="landed_cost_ledger" class="ledger-dropdown form-control" required="required"', $DIS);
+                ?>
+            </div>
+            <?php } ?>
+
 
 
             <div class="form-group ledgers_group" style="display: <?= $warehouse->warehouse_type == 'warehouse' ? 'none' : 'block' ?>;">
@@ -212,6 +233,36 @@
 
             $('#crud-warehouse-form').bootstrapValidator('resetForm');
             var dynamicFields = {};
+
+            if (<?= !empty($warehouse->is_overseas) ? 'true' : 'false' ?>) {
+                dynamicFields.sales_ledger = {
+                    validators: {
+                        notEmpty: { message: 'Please select a Ledger' },
+                        callback: {
+                            message: 'Please select a Ledger',
+                            callback: function(value) { return value !== '0'; }
+                        }
+                    }
+                };
+                dynamicFields.cogs_ledger = {
+                    validators: {
+                        notEmpty: { message: 'Please select a Ledger' },
+                        callback: {
+                            message: 'Please select a Ledger',
+                            callback: function(value) { return value !== '0'; }
+                        }
+                    }
+                };
+                dynamicFields.landed_cost_ledger = {
+                    validators: {
+                        notEmpty: { message: 'Please select a Ledger' },
+                        callback: {
+                            message: 'Please select a Ledger',
+                            callback: function(value) { return value !== '0'; }
+                        }
+                    }
+                };
+            }
 
             if (selectedValue === 'pharmacy') {
                 dynamicFields = {


### PR DESCRIPTION
- Updated the Purchases controller to utilize the new method `canUseLandedCostForWarehouse`, enhancing validation for overseas warehouse access.
- Removed the legacy `getLandedCostLedgerId` method and replaced it with a more robust implementation in the Site model.
- Enhanced the settings view to include fields for sales, COGS, and landed cost ledgers specifically for overseas warehouses.
- Updated language entries to reflect changes in ledger requirements and improve clarity for users.

These changes improve the management of landed costs and ensure proper configuration for overseas warehouses, enhancing the overall user experience.