### PR TITLE
Enhance product listing scope for DataTables in overseas warehouses

### DIFF
--- a/app/controllers/admin/Products.php
+++ b/app/controllers/admin/Products.php
@@ -8207,42 +8207,35 @@ error_reporting(E_ALL);
         $action .= '</ul>
         </div></div>';
         $this->load->library('datatables');
+        $osw_id = $this->site->getOverseasWarehouseId();
+        $is_overseas_wh = $osw_id && (int) $warehouse_id === (int) $osw_id;
         if ($warehouse_id) {
             // wp.rack as rack replaced with 1 as rack
             $this->datatables
                 ->select($this->db->dbprefix('products') . ".id as productid, {$this->db->dbprefix('products')}.image as image, {$this->db->dbprefix('products')}.code as code,{$this->db->dbprefix('products')}.sequence_code as sequence_code, {$this->db->dbprefix('products')}.name as name, {$this->db->dbprefix('brands')}.name as brand, {$this->db->dbprefix('categories')}.name as cname, cost as cost, price as price, SUM(wp.quantity) as quantity, {$this->db->dbprefix('units')}.code as unit, 1 as rack, alert_quantity", false)
                 ->from('products');
-            if ($this->Settings->display_all_products) {
+            if ($this->Settings->display_all_products || $is_overseas_wh) {
                 $this->datatables->join('inventory_movements wp', "wp.product_id=products.id AND wp.location_id={$warehouse_id}", 'left');
-                //$this->datatables->join('warehouses_products wp', "wp.product_id=products.id AND wp.warehouse_id={$warehouse_id}", 'left');
-                // $this->datatables->join("( SELECT product_id, quantity, rack from {$this->db->dbprefix('warehouses_products')} WHERE warehouse_id = {$warehouse_id}) wp", 'products.id=wp.product_id', 'left');
             } else {
                 $this->datatables->join('inventory_movements wp', "wp.product_id=products.id", 'left')
-                    ->where('wp.location_id', $warehouse_id)
-                ;
-                // $this->datatables->join('warehouses_products wp', 'products.id=wp.product_id', 'left')
-                // ->where('wp.warehouse_id', $warehouse_id)
-                // ->where('wp.quantity !=', 0);
+                    ->where('wp.location_id', $warehouse_id);
             }
             $this->datatables->join('categories', 'products.category_id=categories.id', 'left')
                 ->join('units', 'products.unit=units.id', 'left')
                 ->join('brands', 'products.brand=brands.id', 'left')
                 ->group_by("products.id");
+            $this->site->applyProductScopeToDatatables($this->datatables, $warehouse_id);
         } else {
             // wp.rack as rack replaced with 1 as rack
             $this->datatables
                 ->select($this->db->dbprefix('products') . ".id as productid, {$this->db->dbprefix('products')}.image as image, {$this->db->dbprefix('products')}.code as code,{$this->db->dbprefix('products')}.sequence_code as sequence_code, {$this->db->dbprefix('products')}.name as name, {$this->db->dbprefix('brands')}.name as brand, {$this->db->dbprefix('categories')}.name as cname, cost as cost, price as price, SUM(wp.quantity) as quantity, {$this->db->dbprefix('units')}.code as unit, 1 as rack, alert_quantity", false)
                 ->from('products');
             $this->datatables->join('inventory_movements wp', "wp.product_id=products.id", 'left');
-            if ($this->Settings->display_all_products) {
-                //  $this->datatables->join('warehouses_products wp', "wp.product_id=products.id", 'left'); 
-            } else {
-                //  $this->datatables->join('warehouses_products wp', 'products.id=wp.product_id', 'left')->where('wp.quantity !=', 0);     
-            }
             $this->datatables->join('categories', 'products.category_id=categories.id', 'left')
                 ->join('units', 'products.unit=units.id', 'left')
                 ->join('brands', 'products.brand=brands.id', 'left')
                 ->group_by("products.id");
+            $this->site->applyProductScopeToDatatables($this->datatables, null);
         }
         if (!$this->Owner && !$this->Admin) {
             if (!$this->session->userdata('show_cost')) {

--- a/app/models/Site.php
+++ b/app/models/Site.php
@@ -603,6 +603,30 @@ class Site extends CI_Model
         }
     }
 
+    /**
+     * Product listing scope for DataTables (same rules as applyProductScopeFilter).
+     * Overseas warehouse: show tagged products even with zero stock.
+     * Local / all warehouses: hide overseas products unless user can access OSW001.
+     */
+    public function applyProductScopeToDatatables($datatables, $warehouse_id)
+    {
+        $osw_id = $this->getOverseasWarehouseId();
+        if (!$osw_id) {
+            return $datatables;
+        }
+        $prefix = $this->db->dbprefix('products');
+        if ($warehouse_id) {
+            if ((int) $warehouse_id === $osw_id) {
+                $datatables->where($prefix . '.warehouse', $osw_id);
+            } else {
+                $datatables->where("({$prefix}.warehouse IS NULL OR {$prefix}.warehouse = 0 OR {$prefix}.warehouse != {$osw_id})", null, false);
+            }
+        } elseif (!$this->canAccessOverseasWarehouse()) {
+            $datatables->where("({$prefix}.warehouse IS NULL OR {$prefix}.warehouse = 0 OR {$prefix}.warehouse != {$osw_id})", null, false);
+        }
+        return $datatables;
+    }
+
     public function validateProductWarehouseScope($warehouse_id, $product_ids)
     {
         if (empty($product_ids)) {


### PR DESCRIPTION
- Introduced a new method `applyProductScopeToDatatables` in the Site model to manage product visibility based on warehouse access.
- Updated the Products controller to utilize this method, allowing overseas warehouse products to be displayed even with zero stock when applicable.
- Adjusted conditions for displaying products based on user access to overseas warehouses, improving data handling and user experience.

These changes streamline product management and ensure appropriate visibility based on warehouse configurations.