### PR TITLE
Add memo_id handling to payment journal queries

### DIFF
--- a/app/models/Site.php
+++ b/app/models/Site.php
@@ -876,6 +876,7 @@ class Site extends CI_Model
         $pay = $dbp . 'payments';
         $pid = $entries_alias . '.pid';
         $rsid = $entries_alias . '.rsid';
+        $memo_id = $entries_alias . '.memo_id';
         $eid = $entries_alias . '.id';
 
         $paymentJournalSubquery = function ($wh_id) use ($pr, $pay, $purchases) {
@@ -886,6 +887,9 @@ class Site extends CI_Model
                 WHERE pr.journal_id IS NOT NULL AND pu.warehouse_id = " . (int) $wh_id;
         };
 
+        // Petty cash, service invoices, and memos are not tied to a purchase/return warehouse.
+        $nonWarehouseLinked = "(NULLIF({$memo_id}, '') IS NOT NULL AND NULLIF({$memo_id}, 0) IS NOT NULL)";
+
         if ($warehouse_id) {
             $wh = (int) $warehouse_id;
             $journalSql = $paymentJournalSubquery($wh);
@@ -895,6 +899,7 @@ class Site extends CI_Model
                 OR (NULLIF({$rsid}, '') IS NOT NULL AND NULLIF({$rsid}, 0) IS NOT NULL
                     AND {$rsid} IN (SELECT id FROM {$returns} WHERE warehouse_id = {$wh}))
                 OR {$eid} IN ({$journalSql})
+                OR {$nonWarehouseLinked}
             )";
         }
 


### PR DESCRIPTION
- Introduced memo_id to enhance payment journal queries, allowing for better tracking of petty cash, service invoices, and memos not linked to a specific warehouse.
- Updated SQL conditions to include checks for non-null and non-zero memo_id values, improving the accuracy of report data.

These changes improve the clarity and comprehensiveness of financial reporting.