### PR TITLE
Enhance supplier reporting and reconciliation features

### DIFF
--- a/app/controllers/admin/Reports.php
+++ b/app/controllers/admin/Reports.php
@@ -4815,7 +4815,7 @@ class Reports extends MY_Controller
         $default_from = date('d/m/Y', mktime(0, 0, 0, 1, 1, (int)date('Y')));
         $this->data['default_from_date'] = $default_from;
 
-        $this->data['suppliers'] = $this->site->getAllCompanies('supplier');
+        $this->data['suppliers'] = $this->site->getAllChildCompanies('supplier');
         $this->data['warehouses'] = $this->site->getAllWarehouses();
         $warehouse_id = $this->site->resolveReportWarehouseFilter('warehouse_id');
         $this->data['warehouse_id'] = $warehouse_id;
@@ -4853,6 +4853,11 @@ class Reports extends MY_Controller
             $this->data['total_ob_debit'] = $total_ob_debit;
             $this->data['total_ob'] = $this->sma->formatDecimal($total_ob);
             $this->data['supplier_statement'] = $supplier_statement['report'];
+            $this->data['reconciliation'] = $this->reports_model->getSupplierBalanceReconciliation(
+                $supplier_id,
+                $end_date,
+                $warehouse_id
+            );
 
             
 
@@ -4884,12 +4889,20 @@ class Reports extends MY_Controller
      * Diagnostic: compare Supplier Statement ledger balance vs Unpaid Invoices balance
      * for a single supplier.
      *
-     * Access: /admin/reports/debug_supplier_balance/674
-     * Outputs a plain-HTML dump — no layout, no auth check, direct browser output.
+     * Access: /admin/reports/debug_supplier_balance/{supplier_id}?at_date=2026-05-31
+     * Requires reports-supplier-statement permission (Owner/Admin bypass).
      */
-    public function debug_supplier_balance($supplier_id = 674)
+    public function debug_supplier_balance($supplier_id = null)
     {
-        $supplier_id = (int) $supplier_id;
+        if (!$this->Owner && !$this->Admin && empty($this->GP['reports-supplier-statement'])) {
+            show_error('Access denied', 403);
+        }
+
+        $supplier_id = (int) ($supplier_id ?: $this->input->get('supplier_id'));
+        if (!$supplier_id) {
+            show_error('Supplier ID required', 400);
+        }
+
         $pfx         = $this->db->dbprefix; // 'sma_'
 
         $this->db->reset_query();
@@ -4899,6 +4912,15 @@ class Reports extends MY_Controller
         $ledger_id = (int) $sup->ledger_account;
 
         $fmt = fn($v) => number_format((float)$v, 2, '.', ',');
+
+        $at_date_input = $this->input->get('at_date');
+        if ($at_date_input) {
+            $date_cut = strpos($at_date_input, '/') !== false
+                ? $this->sma->fld($at_date_input)
+                : $at_date_input;
+        } else {
+            $date_cut = date('Y-m-d');
+        }
 
         echo "<!doctype html><html><head><meta charset='utf-8'>
         <style>
@@ -4913,7 +4935,7 @@ class Reports extends MY_Controller
             .zero{color:#aaa}
         </style></head><body>";
 
-        $date_cut = '2026-03-31';
+        $date_cut = substr($date_cut, 0, 10);
 
         echo "<h1>Purchase vs Accounting vs Payments — Supplier ID: $supplier_id — {$sup->name}</h1>";
         echo "<p>Supplier Ledger Account ID: <b>$ledger_id</b> &nbsp;|&nbsp; Date filter: up to <b>{$date_cut}</b></p>";
@@ -5637,7 +5659,7 @@ class Reports extends MY_Controller
         $from_date = $this->input->post('from_date') ? $this->input->post('from_date') : null;
         $to_date = $this->input->post('to_date') ? $this->input->post('to_date') : null;
 
-        $this->data['suppliers'] = $this->site->getAllCompanies('supplier');
+        $this->data['suppliers'] = $this->site->getAllChildCompanies('supplier');
         $this->data['biller'] = $this->site->getDefaultBiller();
         $this->data['warehouses'] = $this->site->getAllWarehouses();
         $warehouse_id = $this->site->resolveReportWarehouseFilter('warehouse_id');
@@ -5680,6 +5702,11 @@ class Reports extends MY_Controller
             $this->data['total_ob_debit'] = $total_ob_debit;
             $this->data['total_ob'] = $this->sma->formatDecimal($total_ob);
             $this->data['supplier_statement'] = $supplier_statement['report'];
+            $this->data['reconciliation'] = $this->reports_model->getSupplierBalanceReconciliation(
+                $supplier_id,
+                $end_date,
+                $warehouse_id
+            );
 
             // Set viewtype for PDF rendering
             $this->data['viewtype'] = 'pdf_new';
@@ -6037,7 +6064,7 @@ class Reports extends MY_Controller
         }
         $this->data['supplier_trade_type'] = $supplier_trade_type;
 
-        $all_suppliers = $this->site->getAllChildCompanies('supplier') ?: [];
+        $all_suppliers = $this->site->getAllCompanies('supplier') ?: [];
         $this->data['suppliers'] = array_values(array_filter($all_suppliers, function ($s) use ($supplier_trade_type) {
             $is_service = stripos($s->category ?? '', 'خدمات') !== false || stripos($s->category ?? '', 'service') !== false;
             if ($supplier_trade_type === 'non_trade') {

--- a/app/controllers/admin/Suppliers.php
+++ b/app/controllers/admin/Suppliers.php
@@ -1054,6 +1054,10 @@ class Suppliers extends MY_Controller
             'from_date'    => $this->input->get('from_date')   ?: $this->input->post('from_date'),
             'to_date'      => $this->input->get('to_date')     ?: $this->input->post('to_date'),
         ];
+        // Default from_date to January 1st of the current year
+        if (empty($filters['from_date'])) {
+            $filters['from_date'] = date('d/m/Y', mktime(0, 0, 0, 1, 1, (int) date('Y')));
+        }
         // Convert display date (d/m/Y) to Y-m-d for the query
         foreach (['from_date', 'to_date'] as $f) {
             if (!empty($filters[$f])) {

--- a/app/models/Site.php
+++ b/app/models/Site.php
@@ -887,18 +887,29 @@ class Site extends CI_Model
                 WHERE pr.journal_id IS NOT NULL AND pu.warehouse_id = " . (int) $wh_id;
         };
 
+        // Service-invoice / memo payments have pay.memo_id, not pay.purchase_id — must stay visible with their invoice.
+        $memoPaymentJournalSubquery = function () use ($pr, $pay) {
+            return "SELECT DISTINCT pr.journal_id
+                FROM {$pr} pr
+                INNER JOIN {$pay} pay ON pay.payment_id = pr.id
+                WHERE pr.journal_id IS NOT NULL
+                AND NULLIF(pay.memo_id, '') IS NOT NULL AND NULLIF(pay.memo_id, 0) IS NOT NULL";
+        };
+
         // Petty cash, service invoices, and memos are not tied to a purchase/return warehouse.
         $nonWarehouseLinked = "(NULLIF({$memo_id}, '') IS NOT NULL AND NULLIF({$memo_id}, 0) IS NOT NULL)";
 
         if ($warehouse_id) {
             $wh = (int) $warehouse_id;
             $journalSql = $paymentJournalSubquery($wh);
+            $memoJournalSql = $memoPaymentJournalSubquery();
             return "(
                 (NULLIF({$pid}, '') IS NOT NULL AND NULLIF({$pid}, 0) IS NOT NULL
                     AND {$pid} IN (SELECT id FROM {$purchases} WHERE warehouse_id = {$wh}))
                 OR (NULLIF({$rsid}, '') IS NOT NULL AND NULLIF({$rsid}, 0) IS NOT NULL
                     AND {$rsid} IN (SELECT id FROM {$returns} WHERE warehouse_id = {$wh}))
                 OR {$eid} IN ({$journalSql})
+                OR {$eid} IN ({$memoJournalSql})
                 OR {$nonWarehouseLinked}
             )";
         }

--- a/app/models/admin/Purchases_model.php
+++ b/app/models/admin/Purchases_model.php
@@ -819,11 +819,16 @@ class Purchases_model extends CI_Model
         $payment_ref_tbl = $dbp . 'payment_reference';
         if ($warehouse_id) {
             $this->db->where(
-                "EXISTS (SELECT 1 FROM {$payments_tbl} p
-                    INNER JOIN {$purchases_tbl} pu ON pu.id = p.purchase_id
-                    WHERE p.payment_id = {$payment_ref_tbl}.id
-                    AND p.purchase_id IS NOT NULL AND p.purchase_id > 0
-                    AND pu.warehouse_id = {$warehouse_id})",
+                "(
+                    EXISTS (SELECT 1 FROM {$payments_tbl} p
+                        INNER JOIN {$purchases_tbl} pu ON pu.id = p.purchase_id
+                        WHERE p.payment_id = {$payment_ref_tbl}.id
+                        AND p.purchase_id IS NOT NULL AND p.purchase_id > 0
+                        AND pu.warehouse_id = {$warehouse_id})
+                    OR EXISTS (SELECT 1 FROM {$payments_tbl} p
+                        WHERE p.payment_id = {$payment_ref_tbl}.id
+                        AND NULLIF(p.memo_id, '') IS NOT NULL AND NULLIF(p.memo_id, 0) IS NOT NULL)
+                )",
                 null,
                 false
             );

--- a/app/models/admin/Reports_model.php
+++ b/app/models/admin/Reports_model.php
@@ -1082,8 +1082,112 @@ class Reports_model extends CI_Model
         }
 
         $response_array = array('ob' => $data_res, 'report' => $data);
-        //        dd($response_array);
         return $response_array;
+    }
+
+    /**
+     * Cross-check supplier statement GL balance vs unpaid-invoices (AP) outstanding.
+     *
+     * @return array{gl_statement_balance: float, unpaid_ap_total: float, variance: float, per_invoice_mismatch_count: int}|null
+     */
+    public function getSupplierBalanceReconciliation($supplier_id, $at_date, $warehouse_id = null)
+    {
+        $supplier_info = $this->companies_model->getCompanyByID($supplier_id);
+        if (!$supplier_info) {
+            return null;
+        }
+
+        $supplier_ledger = (int) $supplier_info->ledger_account;
+        $pfx = $this->db->dbprefix;
+        $warehouse_sql = $this->site->reportPurchaseLedgerWarehouseExistsSql($warehouse_id, 'e');
+        $ledger_scope_sql = "(
+            ai.ledger_id = ?
+            OR (
+                e.transaction_type = 'pettycash'
+                AND e.memo_id IS NOT NULL
+                AND e.memo_id != ''
+                AND e.memo_id != 0
+                AND ai.dc = 'C'
+                AND ai.ledger_id != ?
+            )
+        )";
+
+        $gl = $this->db->query("
+            SELECT ROUND(SUM(CASE WHEN ai.dc = 'C' THEN ai.amount ELSE -ai.amount END), 2) AS gl_net_credit
+            FROM {$pfx}accounts_entries e
+            JOIN {$pfx}accounts_entryitems ai ON ai.entry_id = e.id
+            WHERE e.supplier_id = ?
+              AND DATE(e.date) <= ?
+              AND {$ledger_scope_sql}
+              {$warehouse_sql}
+        ", [$supplier_id, $at_date, $supplier_ledger, $supplier_ledger])->row();
+
+        $ap = $this->db->query("
+            SELECT ROUND(COALESCE(SUM(outstanding), 0), 2) AS unpaid_ap_total
+            FROM (
+                SELECT
+                    ROUND(
+                        (p.grand_total + COALESCE(p.grand_deal_discount, 0))
+                        - COALESCE((
+                            SELECT SUM(sp.amount)
+                            FROM {$pfx}payments sp
+                            WHERE sp.purchase_id = p.id AND DATE(sp.date) <= ?
+                        ), 0),
+                    2) AS outstanding
+                FROM {$pfx}purchases p
+                WHERE p.supplier_id = ?
+                  AND p.purchase_invoice = 1
+                  AND p.grand_total > 0
+                  AND p.note != 'import from excel'
+                  AND DATE(p.date) <= ?
+            ) x
+            WHERE outstanding > 0.01
+        ", [$at_date, $supplier_id, $at_date])->row();
+
+        $mismatch = $this->db->query("
+            SELECT COUNT(*) AS mismatch_count
+            FROM (
+                SELECT
+                    ROUND(
+                        (COALESCE(acc.acc_debit, 0) - COALESCE(acc.acc_credit, 0))
+                        - ((p.grand_total + COALESCE(p.grand_deal_discount, 0)) - COALESCE(pay.pay_total, 0)),
+                    2) AS diff
+                FROM {$pfx}purchases p
+                LEFT JOIN (
+                    SELECT e.pid,
+                           SUM(CASE WHEN ai.dc = 'D' THEN ai.amount ELSE 0 END) AS acc_debit,
+                           SUM(CASE WHEN ai.dc = 'C' THEN ai.amount ELSE 0 END) AS acc_credit
+                    FROM {$pfx}accounts_entries e
+                    JOIN {$pfx}accounts_entryitems ai ON ai.entry_id = e.id
+                    WHERE e.supplier_id = ?
+                      AND ai.ledger_id = ?
+                      AND e.pid IS NOT NULL AND e.pid != ''
+                      AND DATE(e.date) <= ?
+                    GROUP BY e.pid
+                ) acc ON acc.pid = p.id
+                LEFT JOIN (
+                    SELECT purchase_id, SUM(amount) AS pay_total
+                    FROM {$pfx}payments
+                    WHERE DATE(date) <= ?
+                    GROUP BY purchase_id
+                ) pay ON pay.purchase_id = p.id
+                WHERE p.supplier_id = ?
+                  AND p.purchase_invoice = 1
+                  AND p.grand_total > 0
+                  AND DATE(p.date) <= ?
+            ) inv
+            WHERE ABS(diff) > 1.00
+        ", [$supplier_id, $supplier_ledger, $at_date, $at_date, $supplier_id, $at_date])->row();
+
+        $gl_balance = (float) ($gl->gl_net_credit ?? 0);
+        $unpaid_ap = (float) ($ap->unpaid_ap_total ?? 0);
+
+        return [
+            'gl_statement_balance' => $gl_balance,
+            'unpaid_ap_total' => $unpaid_ap,
+            'variance' => round($gl_balance - $unpaid_ap, 2),
+            'per_invoice_mismatch_count' => (int) ($mismatch->mismatch_count ?? 0),
+        ];
     }
 
     /**

--- a/themes/blue/admin/views/reports/suppliers_statement.php
+++ b/themes/blue/admin/views/reports/suppliers_statement.php
@@ -145,6 +145,36 @@
                 <hr/>
                 <?php echo form_close(); 
                 } ?>
+                <?php if (($Owner || $Admin) && !empty($reconciliation) && $viewtype != 'pdf' && $viewtype != 'pdf_new'): ?>
+                <div class="well well-sm" style="margin-bottom:15px;">
+                    <strong>Balance reconciliation</strong> <small class="text-muted">(as at <?= htmlspecialchars($end_date ?? ''); ?>)</small>
+                    <table class="table table-bordered table-condensed" style="margin-top:8px; margin-bottom:0; max-width:720px;">
+                        <tr>
+                            <td>Statement closing balance (GL)</td>
+                            <td class="text-right"><?= number_format((float) $reconciliation['gl_statement_balance'], 2, '.', ','); ?></td>
+                        </tr>
+                        <tr>
+                            <td>Unpaid invoices total (AP)</td>
+                            <td class="text-right"><?= number_format((float) $reconciliation['unpaid_ap_total'], 2, '.', ','); ?></td>
+                        </tr>
+                        <tr<?= abs((float) $reconciliation['variance']) > 0.01 ? ' class="danger"' : ''; ?>>
+                            <td><strong>Variance (GL − unpaid AP)</strong></td>
+                            <td class="text-right"><strong><?= number_format((float) $reconciliation['variance'], 2, '.', ','); ?></strong></td>
+                        </tr>
+                    </table>
+                    <?php if (abs((float) $reconciliation['variance']) > 0.01): ?>
+                    <p class="text-muted" style="margin:8px 0 0;">
+                        The statement is GL-based and may differ from unpaid-invoice outstanding when payment allocations and journals disagree.
+                        <?php if (!empty($supplier_id)): ?>
+                        <a href="<?= admin_url('reports/debug_supplier_balance/' . (int) $supplier_id . '?at_date=' . urlencode($end_date ?? '')); ?>" target="_blank">View per-invoice breakdown</a>
+                        <?php endif; ?>
+                        <?php if ((int) $reconciliation['per_invoice_mismatch_count'] > 0): ?>
+                        (<?= (int) $reconciliation['per_invoice_mismatch_count']; ?> invoice(s) with allocation mismatch &gt; 1 SAR)
+                        <?php endif; ?>
+                    </p>
+                    <?php endif; ?>
+                </div>
+                <?php endif; ?>
                 <div class="row">
                     <div class="controls table-controls" style="font-size: 12px !important;">
                         <table id="poTable"
@@ -236,9 +266,9 @@
                                 }else if($statement->transaction_type == 'creditmemo' || $statement->transaction_type == 'debitmemo'){
                                     $link = admin_url('customers/view_credit_memo/' . $statement->memo_id);
                                     $transaction_type = 'Memo';
-                                }else if($statement->transaction_type == 'serviceinvoice'){
-                                    $link = admin_url('customers/list_service_invoice');
-                                    $transaction_type = 'Service Invoice';
+                }else if($statement->transaction_type == 'serviceinvoice'){
+                    $link = !empty($statement->memo_id) ? admin_url('suppliers/edit_service_invoice/' . $statement->memo_id) : admin_url('suppliers/list_service_invoice');
+                    $transaction_type = 'Service Invoice';
                                 }else if($statement->transaction_type == 'pettycash'){
                                     $link = !empty($statement->memo_id) ? admin_url('suppliers/petty_cash_pdf/' . $statement->memo_id) : null;
                                     $transaction_type = 'Petty Cash';


### PR DESCRIPTION
- Updated the Reports controller to retrieve child companies instead of all suppliers for improved accuracy in supplier statements.
- Added a reconciliation feature to compare supplier statement balances against unpaid invoices, providing insights into discrepancies.
- Enhanced the debug_supplier_balance method to accept supplier_id as a query parameter, improving flexibility in accessing supplier balance reports.
- Updated the suppliers_statement view to display reconciliation results, including GL balance, unpaid invoices total, and variance, enhancing user visibility into supplier financials.

These changes improve the accuracy and usability of supplier reporting and reconciliation processes.