### PR TITLE
Implement validation for sale product lines to prevent duplicates and…

### DIFF
--- a/app/controllers/admin/Sales.php
+++ b/app/controllers/admin/Sales.php
@@ -330,6 +330,11 @@ class Sales extends MY_Controller
 
             $attachments        = $this->attachments->upload();
             $data['attachment'] = !empty($attachments);
+
+            if ($product_error = $this->_validateSaleProductLines($warehouse_id, $products, $sale_status)) {
+                $this->session->set_flashdata('error', $product_error);
+                redirect($_SERVER['HTTP_REFERER']);
+            }
         }
 
         if ($this->form_validation->run() == true && $this->sales_model->addSale($data, $products, $payment, [], $attachments)) {
@@ -521,6 +526,11 @@ class Sales extends MY_Controller
         ];
 
         $payment = [];
+
+        if ($product_error = $this->_validateSaleProductLines($warehouse_id, $products, 'ready')) {
+            $this->session->set_flashdata('error', $product_error);
+            admin_redirect('quotes');
+        }
 
         if ($sale_id = $this->sales_model->addSaleNew($data, $products, $payment, [])) {
 
@@ -767,6 +777,11 @@ class Sales extends MY_Controller
         ];
 
         $payment = [];
+
+        if ($product_error = $this->_validateSaleProductLines($warehouse_id, $products, 'ready')) {
+            $this->session->set_flashdata('error', $product_error);
+            admin_redirect('quotes');
+        }
 
         if ($sale_id = $this->sales_model->addSaleNew($data, $products, $payment, [])) {
 
@@ -1129,6 +1144,11 @@ class Sales extends MY_Controller
 
             $attachments        = $this->attachments->upload();
             $data['attachment'] = !empty($attachments);
+
+            if ($product_error = $this->_validateSaleProductLines($warehouse_id, $products, $sale_status)) {
+                $this->session->set_flashdata('error', $product_error);
+                redirect($_SERVER['HTTP_REFERER']);
+            }
             //$this->sma->print_arrays($data, $products, $payment, $attachments); exit; 
         }
         
@@ -2145,6 +2165,11 @@ class Sales extends MY_Controller
 
             $attachments        = $this->attachments->upload();
             $data['attachment'] = !empty($attachments);
+
+            if ($product_error = $this->_validateSaleProductLines($warehouse_id, $products, $sale_status, $id)) {
+                $this->session->set_flashdata('error', $product_error);
+                admin_redirect('sales/edit/' . $id);
+            }
             //$this->sma->print_arrays($data, $products);exit;
         }
         // echo "<pre>";
@@ -6326,6 +6351,11 @@ if($inv->warning_note != ""){
 
             $attachments        = $this->attachments->upload();
             $data['attachment'] = !empty($attachments);
+
+            if ($product_error = $this->_validateSaleProductLines($warehouse_id, $products, $sale_status)) {
+                $this->session->set_flashdata('error', $product_error);
+                redirect($_SERVER['HTTP_REFERER']);
+            }
             // $this->sma->print_arrays($data, $products, $payment);
         }
 
@@ -7474,6 +7504,30 @@ if($inv->warning_note != ""){
             $this->session->set_flashdata('error', lang('Could not delete request'));
             admin_redirect('sales/qty_onhold_requests');
         }
+    }
+
+    /**
+     * Block duplicate product/batch lines and overselling when saving sales.
+     *
+     * @return string|false Error message HTML or false when valid
+     */
+    private function _validateSaleProductLines($warehouse_id, $products, $sale_status, $exclude_sale_id = null)
+    {
+        if (empty($products)) {
+            return false;
+        }
+
+        $inventory_statuses = ['completed', 'ready'];
+        $result = $this->products_model->validateSaleProducts($warehouse_id, $products, [
+            'check_stock'     => in_array($sale_status, $inventory_statuses, true),
+            'exclude_sale_id' => $exclude_sale_id,
+        ]);
+
+        if ($result['valid']) {
+            return false;
+        }
+
+        return implode('<br>', $result['errors']);
     }
 
 }

--- a/app/models/admin/Products_model.php
+++ b/app/models/admin/Products_model.php
@@ -2141,4 +2141,133 @@ class Products_model extends CI_Model
     return false;
 }
 
+    /**
+     * On-hand quantity for a product/batch in a warehouse (inventory_movements ledger).
+     */
+    public function getBatchStockQuantity($warehouse_id, $product_id, $batch_no, $expiry = null, $avz_code = null, $exclude_sale_id = null)
+    {
+        $this->db->select('COALESCE(SUM(im.quantity), 0) AS total_quantity', false);
+        $this->db->from('inventory_movements im');
+        $this->db->where('im.location_id', (int) $warehouse_id);
+        $this->db->where('im.product_id', (int) $product_id);
+        $this->db->where('im.batch_number', (string) $batch_no);
+        if ($expiry) {
+            $this->db->where('im.expiry_date', $expiry);
+        }
+        $avz_code = trim((string) $avz_code);
+        if ($avz_code !== '' && strtolower($avz_code) !== 'null') {
+            $this->db->where('im.avz_item_code', $avz_code);
+        }
+        if ($exclude_sale_id) {
+            $this->db->where('NOT (im.type = \'sale\' AND im.reference_id = ' . (int) $exclude_sale_id . ')', null, false);
+        }
+        $row = $this->db->get()->row();
+        return $row ? (float) $row->total_quantity : 0.0;
+    }
+
+    /**
+     * Build a stable key for a sale line (product + batch + expiry + AVZ).
+     */
+    public function saleLineKey($product)
+    {
+        $expiry = $product['expiry'] ?? '';
+        if ($expiry && strpos($expiry, '/') !== false) {
+            $expiry = date('Y-m-d', strtotime(str_replace('/', '-', $expiry)));
+        } elseif ($expiry) {
+            $expiry = date('Y-m-d', strtotime($expiry));
+        }
+        return implode('|', [
+            (int) ($product['product_id'] ?? 0),
+            trim((string) ($product['batch_no'] ?? '')),
+            $expiry,
+            trim((string) ($product['avz_item_code'] ?? '')),
+        ]);
+    }
+
+    /**
+     * Validate sale lines: no duplicate product/batch rows; sufficient stock when posting inventory.
+     *
+     * @return array{valid:bool,errors:string[]}
+     */
+    public function validateSaleProducts($warehouse_id, $products, $options = [])
+    {
+        $errors      = [];
+        $seen        = [];
+        $aggregated  = [];
+        $check_stock = $options['check_stock'] ?? true;
+        $exclude_sale_id = $options['exclude_sale_id'] ?? null;
+
+        foreach ($products as $product) {
+            $type = $product['product_type'] ?? 'standard';
+            if (in_array($type, ['manual', 'digital'], true)) {
+                continue;
+            }
+
+            $batch_no = trim((string) ($product['batch_no'] ?? ''));
+            if ($batch_no === '') {
+                continue;
+            }
+
+            $key = $this->saleLineKey($product);
+            $name = $product['product_name'] ?? ('Product #' . ($product['product_id'] ?? ''));
+            $avz  = trim((string) ($product['avz_item_code'] ?? ''));
+
+            if (isset($seen[$key])) {
+                $errors[] = sprintf(
+                    'Duplicate line: %s (batch %s, AVZ %s) appears more than once on this invoice.',
+                    $name,
+                    $batch_no,
+                    $avz !== '' ? $avz : '—'
+                );
+            }
+            $seen[$key] = true;
+
+            $qty = isset($product['unit_quantity'])
+                ? (float) $product['unit_quantity'] + (float) ($product['bonus'] ?? 0)
+                : (float) ($product['quantity'] ?? 0);
+
+            if (!isset($aggregated[$key])) {
+                $aggregated[$key] = ['qty' => 0, 'product' => $product];
+            }
+            $aggregated[$key]['qty'] += $qty;
+        }
+
+        if ($check_stock && empty($this->Settings->overselling)) {
+            foreach ($aggregated as $agg) {
+                $product  = $agg['product'];
+                $required = $agg['qty'];
+                $expiry   = $product['expiry'] ?? null;
+                if ($expiry && strpos($expiry, '/') !== false) {
+                    $expiry = date('Y-m-d', strtotime(str_replace('/', '-', $expiry)));
+                } elseif ($expiry) {
+                    $expiry = date('Y-m-d', strtotime($expiry));
+                }
+
+                $available = $this->getBatchStockQuantity(
+                    $warehouse_id,
+                    $product['product_id'],
+                    $product['batch_no'],
+                    $expiry,
+                    $product['avz_item_code'] ?? null,
+                    $exclude_sale_id
+                );
+
+                if ($required > $available + 0.00001) {
+                    $name = $product['product_name'] ?? ('Product #' . $product['product_id']);
+                    $avz  = trim((string) ($product['avz_item_code'] ?? ''));
+                    $errors[] = sprintf(
+                        'Insufficient stock for %s (batch %s, AVZ %s): requested %s, available %s.',
+                        $name,
+                        $product['batch_no'],
+                        $avz !== '' ? $avz : '—',
+                        $this->sma->formatDecimal($required, 2),
+                        $this->sma->formatDecimal($available, 2)
+                    );
+                }
+            }
+        }
+
+        return ['valid' => empty($errors), 'errors' => $errors];
+    }
+
 }

--- a/themes/blue/admin/assets/js/sales.js
+++ b/themes/blue/admin/assets/js/sales.js
@@ -1,6 +1,18 @@
 $(document).ready(function (e) {
 	$("body a, body button").attr("tabindex", -1);
 	check_add_item_val();
+
+	$(document).on("click", "#add_sale, #edit_sale", function (e) {
+		if ($(this).prop("disabled")) {
+			e.preventDefault();
+			return false;
+		}
+		if (!validateSaleLinesBeforeSubmit()) {
+			e.preventDefault();
+			return false;
+		}
+	});
+
 	if (site.settings.set_focus != 1) {
 		$("#add_item").focus();
 	}
@@ -1236,6 +1248,16 @@ $(document).ready(function (e) {
 			slitems[item_id].row.price = batchSalePrice;
 
 			slitems[item_id].row.batch_no = new_batchno;
+
+			if (isDuplicateSaleLine(slitems[item_id].row, item_id)) {
+				slitems[item_id].row.batch_no = old_row_batchno;
+				bootbox.alert(
+					"This product/batch is already on the invoice."
+				);
+				$(this).val(old_row_batchno);
+				return;
+			}
+
 			localStorage.setItem("slitems", JSON.stringify(slitems));
 			loadItems();
 		});
@@ -1593,6 +1615,31 @@ function loadItems() {
 						return [parseInt(o.order)];
 				  })
 				: slitems;
+
+		var saleLineTotals = {};
+		var saleDuplicateKeys = {};
+		var saleKeysSeen = {};
+		$.each(sortedItems, function () {
+			var row = this.row;
+			if (!row || row.type === "manual" || row.type === "digital") {
+				return;
+			}
+			var batch = (row.batch_no || "").toString().trim();
+			if (batch === "") {
+				return;
+			}
+			var lineKey = saleLineKey(row);
+			var lineQty =
+				parseFloat(row.qty || 0) + parseFloat(row.bonus || 0);
+			saleLineTotals[lineKey] = (saleLineTotals[lineKey] || 0) + lineQty;
+			if (saleKeysSeen[lineKey]) {
+				saleDuplicateKeys[lineKey] = true;
+			} else {
+				saleKeysSeen[lineKey] = true;
+			}
+		});
+
+		var saleLinesBlocked = false;
 		$("#add_sale, #edit_sale").attr("disabled", false);
 
 	    /**
@@ -2133,12 +2180,26 @@ function loadItems() {
             }*/
 			
 			// Thi will override all the above checks
+			var currentLineKey = saleLineKey(item.row);
+			var currentLineQty =
+				parseFloat(item_qty || 0) + parseFloat(item_bonus || 0);
+			var batchStock = parseFloat(item_batchQuantity);
+			var lineHasIssue = false;
+
+			if (saleDuplicateKeys[currentLineKey]) {
+				lineHasIssue = true;
+			}
 			if (
-				parseFloat(parseFloat(item_qty) + parseFloat(item_bonus)) > parseFloat(base_quantity)
+				site.settings.overselling != 1 &&
+				!isNaN(batchStock) &&
+				saleLineTotals[currentLineKey] > batchStock
 			) {
+				lineHasIssue = true;
+			}
+			if (lineHasIssue) {
 				$("#row_" + row_no).addClass("danger");
 				if (site.settings.overselling != 1) {
-					$("#add_sale, #edit_sale").attr("disabled", true);
+					saleLinesBlocked = true;
 				}
 			}
 
@@ -2179,6 +2240,10 @@ function loadItems() {
 		
 		tfoot += '</th></tr>';
 		$("#slTable tfoot").html(tfoot);
+
+		if (saleLinesBlocked) {
+			$("#add_sale, #edit_sale").attr("disabled", true);
+		}
 
 		// Order level discount calculations
 		if ((sldiscount = localStorage.getItem("sldiscount"))) {
@@ -2244,6 +2309,98 @@ function loadItems() {
 }
 
 /* -----------------------------
+ * Sale line helpers (duplicate + stock)
+ ----------------------------- */
+function saleLineKey(row) {
+	if (!row) {
+		return "";
+	}
+	var pid = row.id || "";
+	var batch = (row.batch_no || "").toString().trim();
+	var expiry = (row.expiry || "").toString().trim();
+	var avz = (row.avz_item_code || "").toString().trim();
+	return pid + "|" + batch + "|" + expiry + "|" + avz;
+}
+
+function isDuplicateSaleLine(row, excludeItemId) {
+	if (!row || row.type === "manual" || row.type === "digital") {
+		return false;
+	}
+	var batch = (row.batch_no || "").toString().trim();
+	if (batch === "") {
+		return false;
+	}
+	var key = saleLineKey(row);
+	var duplicate = false;
+	$.each(slitems, function (id, item) {
+		if (excludeItemId && id == excludeItemId) {
+			return;
+		}
+		if (item.row && saleLineKey(item.row) === key) {
+			duplicate = true;
+			return false;
+		}
+	});
+	return duplicate;
+}
+
+function validateSaleLinesBeforeSubmit() {
+	var totals = {};
+	var seen = {};
+	var duplicates = false;
+	var oversold = false;
+
+	$.each(slitems, function () {
+		var row = this.row;
+		if (!row || row.type === "manual" || row.type === "digital") {
+			return;
+		}
+		var batch = (row.batch_no || "").toString().trim();
+		if (batch === "") {
+			return;
+		}
+		var key = saleLineKey(row);
+		var qty = parseFloat(row.qty || 0) + parseFloat(row.bonus || 0);
+		totals[key] = (totals[key] || 0) + qty;
+		if (seen[key]) {
+			duplicates = true;
+		}
+		seen[key] = true;
+	});
+
+	if (duplicates) {
+		bootbox.alert(
+			"Duplicate product/batch lines found on this invoice. Remove or merge them before saving."
+		);
+		return false;
+	}
+
+	if (site.settings.overselling != 1) {
+		$.each(slitems, function () {
+			var row = this.row;
+			if (!row || row.type === "manual" || row.type === "digital") {
+				return;
+			}
+			var key = saleLineKey(row);
+			var batchStock = parseFloat(row.batchQuantity);
+			if (!isNaN(batchStock) && totals[key] > batchStock) {
+				oversold = true;
+				return false;
+			}
+		});
+	}
+
+	if (oversold) {
+		bootbox.alert(
+			"Insufficient stock for one or more lines. Reduce quantities or choose another batch."
+		);
+		return false;
+	}
+
+	return true;
+}
+
+/* -----------------------------
  * Add Sale Order Item Function
  * @param {json} item
  * @returns {Boolean}
@@ -2261,6 +2418,11 @@ function add_invoice_item(item) {
 		}
 	}
 	if (item == null) return;
+
+	if (item.row && isDuplicateSaleLine(item.row)) {
+		bootbox.alert("This product/batch is already on the invoice.");
+		return false;
+	}
 
 	var item_id = site.settings.item_addition == 1 ? item.item_id : item.id;
 	if (slitems[item_id]) {

--- a/themes/blue/admin/views/sales/add.php
+++ b/themes/blue/admin/views/sales/add.php
@@ -191,17 +191,9 @@ table#slTable td input.form-control {
                                     if(data){
 
                                         var avzItemCode = data[0].row.avz_item_code;
-                                        var found = false;
-
-                                        Object.keys(slitems).forEach(function (key) {
-                                            if (slitems[key].row && slitems[key].row.avz_item_code === avzItemCode) {
-                                                found = true;
-                                            }
-                                        });
-
-                                        if(found == true){
-                                            bootbox.alert('Row already exists for this code.');
-                                        }else{
+                                        if (data[0].row && isDuplicateSaleLine(data[0].row)) {
+                                            bootbox.alert('This product/batch is already on the invoice.');
+                                        } else {
                                             add_invoice_item(data[0]);
                                         }
                                     }else{
@@ -325,13 +317,7 @@ table#slTable td input.form-control {
                         count++;
 
                         var avzItemCode = item.row.avz_item_code;
-                        var found = false;
-
-                        Object.keys(slitems).forEach(function (key) {
-                            if (slitems[key].row && slitems[key].row.avz_item_code === avzItemCode) {
-                                found = true;
-                            }
-                        });
+                        var found = isDuplicateSaleLine(item.row);
 
                         var tickOrCross = found ? '✔' : '✖';
 
@@ -381,7 +367,7 @@ table#slTable td input.form-control {
                             if(!available){
                                 add_invoice_item(selectedItem);
                             }else{
-                                bootbox.alert('Row already added');
+                                bootbox.alert('This product/batch is already on the invoice.');
                             }
                         }else{
                             console.log('Item not found');

--- a/themes/blue/admin/views/sales/edit.php
+++ b/themes/blue/admin/views/sales/edit.php
@@ -92,17 +92,9 @@ $allow_discount = ($Owner || $Admin || $this->session->userdata('allow_discount'
                                     $(this).removeClass('ui-autocomplete-loading');
                                     if(data){
                                         var avzItemCode = data[0].row.avz_item_code;
-                                        var found = false;
-
-                                        Object.keys(slitems).forEach(function (key) {
-                                            if (slitems[key].row && slitems[key].row.avz_item_code === avzItemCode) {
-                                                found = true;
-                                            }
-                                        });
-
-                                        if(found == true){
-                                            bootbox.alert('Row already exists for this code.');
-                                        }else{
+                                        if (data[0].row && isDuplicateSaleLine(data[0].row)) {
+                                            bootbox.alert('This product/batch is already on the invoice.');
+                                        } else {
                                             add_invoice_item(data[0]);
                                         }
                                     }else{
@@ -229,13 +221,7 @@ $allow_discount = ($Owner || $Admin || $this->session->userdata('allow_discount'
                         count++;
 
                         var avzItemCode = item.row.avz_item_code;
-                        var found = false;
-
-                        Object.keys(slitems).forEach(function (key) {
-                            if (slitems[key].row && slitems[key].row.avz_item_code === avzItemCode) {
-                                found = true;
-                            }
-                        });
+                        var found = isDuplicateSaleLine(item.row);
 
                         var tickOrCross = found ? '✔' : '✖';
 
@@ -285,7 +271,7 @@ $allow_discount = ($Owner || $Admin || $this->session->userdata('allow_discount'
                             if(!available){
                                 add_invoice_item(selectedItem);
                             }else{
-                                bootbox.alert('Row already added');
+                                bootbox.alert('This product/batch is already on the invoice.');
                             }
                         }else{
                             console.log('Item not found');


### PR DESCRIPTION
… overselling

- Added a new private method `_validateSaleProductLines` in the Sales controller to check for duplicate product/batch lines and ensure sufficient stock when saving sales.
- Updated the Sales controller to utilize this validation method during sale creation and editing processes, providing user feedback through flash messages.
- Enhanced JavaScript functions in the sales view to validate sale lines before submission, preventing duplicates and checking stock availability.
- Improved user alerts for duplicate entries and insufficient stock scenarios in the sales interface.

These changes enhance the integrity of sales data and improve user experience by preventing common errors during the sales process.