### PR TITLE
Refactor report and supplier handling

### DIFF
--- a/app/controllers/admin/Reports.php
+++ b/app/controllers/admin/Reports.php
@@ -4813,9 +4813,9 @@ class Reports extends MY_Controller
         $this->data['error'] = (validation_errors()) ? validation_errors() : $this->session->flashdata('error');
 
         $response_arr = array();
-        $viewtype = $this->input->post('viewtype') ? $this->input->post('viewtype') : null;
-        $from_date = $this->input->post('from_date') ? $this->input->post('from_date') : null;
-        $to_date = $this->input->post('to_date') ? $this->input->post('to_date') : null;
+        $viewtype = $this->input->post('viewtype') ?: $this->input->get('viewtype');
+        $from_date = $this->input->post('from_date') ?: $this->input->get('from_date');
+        $to_date = $this->input->post('to_date') ?: $this->input->get('to_date');
 
         $this->data['start_date'] = $this->sma->hrsd(date('Y-01-01'));
         $this->data['end_date'] = $this->sma->hrsd(date('Y-m-d'));
@@ -4828,7 +4828,7 @@ class Reports extends MY_Controller
         if ($from_date) {
             $start_date = $this->sma->fld($from_date);
             $end_date = $this->sma->fld($to_date);
-            $supplier_id = $this->input->post('supplier');
+            $supplier_id = $this->input->post('supplier') ?: $this->input->get('supplier');
 
 
             $supplier_details = $this->companies_model->getCompanyByID($supplier_id);

--- a/app/controllers/admin/Suppliers.php
+++ b/app/controllers/admin/Suppliers.php
@@ -3107,10 +3107,10 @@ class Suppliers extends MY_Controller
      * Build payable-side debit lines for supplier payment journal.
      * Petty cash replenishments debit the memo petty cash ledger; other settlements debit supplier AP.
      */
-    private function buildSupplierPaymentPayableDebitLines($supplier, $invoice_details, $service_invoice_details, $debit_memo_details, $credit_memo_details, $advance_amount)
+    private function buildSupplierPaymentPayableDebitLines($supplier, $invoice_details, $service_invoice_details, $debit_memo_details, $credit_memo_details)
     {
         $lines = [];
-        $supplier_payable = (float) $advance_amount;
+        $supplier_payable = 0.0;
 
         foreach ($invoice_details as $detail) {
             $supplier_payable += (float) $detail['total_paying'];
@@ -3510,8 +3510,7 @@ class Suppliers extends MY_Controller
                 $invoice_details,
                 $service_invoice_details,
                 $debit_memo_details,
-                $credit_memo_details,
-                $advance_amount
+                $credit_memo_details
             );
             $journal_id = $this->convert_supplier_payment_multiple_invoice_new(
                 $supplier_id, $ledger_account, $bank_charges_account,

--- a/app/language/english/admin/sma_lang.php
+++ b/app/language/english/admin/sma_lang.php
@@ -693,6 +693,7 @@ $lang['customer_advance_statement'] = 'Customer Advance Statement';
 $lang['supplier_advance_ledger_not_configured'] = 'Supplier advance ledger is not configured in settings.';
 $lang['customer_advance_ledger_not_configured'] = 'Customer advance ledger is not configured in settings.';
 $lang['click_to_view_history']      = 'Click to view advance history';
+$lang['click_to_view_supplier_statement'] = 'Click to view supplier statement';
 $lang['customer_advance']           = 'Customer Advance';
 $lang['back']                       = 'Back';
 $lang['customer_payments']          = 'Customer Payments';

--- a/app/models/Site.php
+++ b/app/models/Site.php
@@ -1169,6 +1169,8 @@ class Site extends CI_Model
         $pid = $entries_alias . '.pid';
         $rsid = $entries_alias . '.rsid';
         $memo_id = $entries_alias . '.memo_id';
+        $supplier_id_col = $entries_alias . '.supplier_id';
+        $txn_type = $entries_alias . '.transaction_type';
         $eid = $entries_alias . '.id';
 
         $paymentJournalSubquery = function ($wh_id) use ($pr, $pay, $purchases) {
@@ -1188,8 +1190,15 @@ class Site extends CI_Model
                 AND NULLIF(pay.memo_id, '') IS NOT NULL AND NULLIF(pay.memo_id, 0) IS NOT NULL";
         };
 
-        // Petty cash, service invoices, and memos are not tied to a purchase/return warehouse.
+        // Petty cash, service invoices, memos, and orphan AP uploads are not tied to a purchase warehouse.
         $nonWarehouseLinked = "(NULLIF({$memo_id}, '') IS NOT NULL AND NULLIF({$memo_id}, 0) IS NOT NULL)";
+        $orphanSupplierAp = "(
+            NULLIF({$supplier_id_col}, '') IS NOT NULL AND NULLIF({$supplier_id_col}, 0) IS NOT NULL
+            AND (NULLIF({$pid}, '') IS NULL OR NULLIF({$pid}, 0) IS NULL)
+            AND (NULLIF({$rsid}, '') IS NULL OR NULLIF({$rsid}, 0) IS NULL)
+            AND (NULLIF({$memo_id}, '') IS NULL OR NULLIF({$memo_id}, 0) IS NULL)
+            AND {$txn_type} IN ('purchase_invoice', 'service_invoice')
+        )";
 
         if ($warehouse_id) {
             $wh = (int) $warehouse_id;
@@ -1203,6 +1212,7 @@ class Site extends CI_Model
                 OR {$eid} IN ({$journalSql})
                 OR {$eid} IN ({$memoJournalSql})
                 OR {$nonWarehouseLinked}
+                OR {$orphanSupplierAp}
             )";
         }
 

--- a/themes/blue/admin/views/reports/suppliers_trial_balance.php
+++ b/themes/blue/admin/views/reports/suppliers_trial_balance.php
@@ -13,8 +13,13 @@
        document.getElementById("searchForm").submit();
        $('.viewtype').val(''); 
     } 
-    $(document).ready(function() {
-
+    $(document).ready(function () {
+        $('#poTable tbody tr.supplier-tb-row').on('click', function () {
+            var href = $(this).data('href');
+            if (href) {
+                window.location.href = href;
+            }
+        });
     });
 </script>
 <?php if($viewtype=='pdf'){ ?>
@@ -153,9 +158,16 @@
                                     $totalFinalEndCredit += $finalEndCredit;
 
 
+                                $detail_url = admin_url('reports/supplier_statement')
+                                    . '?supplier=' . (int) $data['supplier_id']
+                                    . '&from_date=' . urlencode($start_date ?? '')
+                                    . '&to_date=' . urlencode($end_date ?? '');
+                                if (!empty($warehouse_id)) {
+                                    $detail_url .= '&warehouse_id=' . (int) $warehouse_id;
+                                }
                                 $count++;
                                 ?>
-                                <tr>
+                                <tr class="supplier-tb-row" style="cursor:pointer;" data-href="<?= $detail_url; ?>" title="<?= lang('click_to_view_supplier_statement'); ?>">
                                     <td><?= $count; ?></td>
                                     <td><?= $data['sequence_code']; ?></td>
                                     <td><?= $data['name']; ?></td>

--- a/themes/green/admin/views/reports/suppliers_trial_balance.php
+++ b/themes/green/admin/views/reports/suppliers_trial_balance.php
@@ -1,7 +1,12 @@
 <?php defined('BASEPATH') or exit('No direct script access allowed'); ?>
 <script>
     $(document).ready(function () {
-
+        $('#poTable tbody tr.supplier-tb-row').on('click', function () {
+            var href = $(this).data('href');
+            if (href) {
+                window.location.href = href;
+            }
+        });
     });
 </script>
 <div class="box">
@@ -103,9 +108,16 @@
                                     $totalFinalEndCredit += $finalEndCredit;
 
 
+                                $detail_url = admin_url('reports/supplier_statement')
+                                    . '?supplier=' . (int) $data['supplier_id']
+                                    . '&from_date=' . urlencode($start_date ?? '')
+                                    . '&to_date=' . urlencode($end_date ?? '');
+                                if (!empty($warehouse_id)) {
+                                    $detail_url .= '&warehouse_id=' . (int) $warehouse_id;
+                                }
                                 $count++;
                                 ?>
-                                <tr>
+                                <tr class="supplier-tb-row" style="cursor:pointer;" data-href="<?= $detail_url; ?>" title="<?= lang('click_to_view_supplier_statement'); ?>">
                                     <td><?= $count; ?></td>
                                     <td><?= $data['sequence_code']; ?></td>
                                     <td><?= $data['name']; ?></td>


### PR DESCRIPTION
- Updated Reports controller to allow fetching viewtype, from_date, and to_date from both POST and GET requests for improved flexibility.
- Modified Suppliers controller to initialize supplier payable to zero and removed the advance_amount parameter from the buildSupplierPaymentPayableDebitLines method.
- Enhanced language file to include a new entry for viewing supplier statements.
- Updated Site model to include logic for orphan supplier accounts payable.
- Improved supplier trial balance views to enable clickable rows for detailed supplier statements.

These changes enhance the reporting capabilities and streamline supplier payment processing within the application.