### PR TITLE
Add VAT ledger handling for sales and deliveries

### DIFF
--- a/app/controllers/admin/Delivery.php
+++ b/app/controllers/admin/Delivery.php
@@ -324,6 +324,10 @@ class Delivery extends MY_Controller
             $customer           = $this->companies_model->getCompanyByID($inv->customer_id);
             $inv_items          = $this->sales_model->getAllSaleItems($sid);
             $warehouse_ledgers  = $this->site->getWarehouseByID($inv->warehouse_id);
+            $vat_ledger_id      = $this->site->getVatOnSaleLedgerId($warehouse_ledgers);
+            if (!$vat_ledger_id && (float) $inv->total_tax > 0) {
+                log_message('error', 'Delivery auto-convert: VAT on sale ledger not configured (sale_id=' . (int) $sid . ')');
+            }
 
             // Accounting entry header
             $entry = [
@@ -347,8 +351,10 @@ class Delivery extends MY_Controller
                 ['dc' => 'D', 'ledger_id' => $customer->discount_ledger,           'amount' => $inv->total_discount,  'narration' => 'total discount'],
                 ['dc' => 'D', 'ledger_id' => $customer->ledger_account,            'amount' => $inv->grand_total,     'narration' => 'customer'],
                 ['dc' => 'C', 'ledger_id' => $this->site->usesWarehouseGL($warehouse_ledgers) ? $warehouse_ledgers->sales_ledger : $customer->sales_ledger, 'amount' => $inv->total, 'narration' => 'sale account'],
-                ['dc' => 'C', 'ledger_id' => $this->vat_on_sale,                   'amount' => $inv->total_tax,       'narration' => 'vat on sale'],
             ];
+            if ($vat_ledger_id) {
+                $lines[] = ['dc' => 'C', 'ledger_id' => $vat_ledger_id, 'amount' => $inv->total_tax, 'narration' => 'vat on sale'];
+            }
             foreach ($lines as $line) {
                 $this->db->insert('sma_accounts_entryitems', array_merge(['entry_id' => $insert_id], $line));
             }

--- a/app/controllers/admin/Sales.php
+++ b/app/controllers/admin/Sales.php
@@ -2877,6 +2877,10 @@ class Sales extends MY_Controller
             $inv_items = $this->sales_model->getAllSaleItems($sid);
             $warehouse_id = $inv->warehouse_id;
             $warehouse_ledgers = $this->site->getWarehouseByID($warehouse_id);
+            $vat_ledger_id = $this->site->getVatOnSaleLedgerId($warehouse_ledgers);
+            if (!$vat_ledger_id && (float) $inv->total_tax > 0) {
+                log_message('error', 'convert_sale_invoice: VAT on sale ledger not configured (sale_id=' . (int) $sid . ')');
+            }
 
             /*Accounts Entries*/
             $entry = array(
@@ -2967,21 +2971,18 @@ class Sales extends MY_Controller
             );
           
           
-             // //vat on sale
-             $entryitemdata[] = array(
-                         'Entryitem' => array(
-                             'entry_id' => $insert_id,
-                             'dc' => 'C',
-                             'ledger_id' => $this->vat_on_sale,
-                             'amount' => $inv->total_tax,
-                             'narration' => 'vat on sale'
-                         )
-                     );
- 
- 
+            if ($vat_ledger_id) {
+                $entryitemdata[] = array(
+                    'Entryitem' => array(
+                        'entry_id' => $insert_id,
+                        'dc' => 'C',
+                        'ledger_id' => $vat_ledger_id,
+                        'amount' => $inv->total_tax,
+                        'narration' => 'vat on sale'
+                    )
+                );
+            }
 
-           
-                     
             //   /*Accounts Entry Items*/
             foreach ($entryitemdata as $row => $itemdata)
             {

--- a/app/models/Site.php
+++ b/app/models/Site.php
@@ -681,6 +681,21 @@ class Site extends CI_Model
         return $warehouse && (!empty($warehouse->is_overseas) || $warehouse->warehouse_type == 'pharmacy');
     }
 
+    /**
+     * VAT output ledger for sale invoices (settings first, then warehouse fallback).
+     */
+    public function getVatOnSaleLedgerId($warehouse = null)
+    {
+        $settings = $this->get_setting();
+        if ($settings && !empty($settings->vat_on_sale_ledger)) {
+            return (int) $settings->vat_on_sale_ledger;
+        }
+        if ($warehouse && !empty($warehouse->vat_on_sales_ledger)) {
+            return (int) $warehouse->vat_on_sales_ledger;
+        }
+        return 0;
+    }
+
     public function applyProductScopeFilter($warehouse_id)
     {
         $osw_id = $this->getOverseasWarehouseId();


### PR DESCRIPTION
- Introduced `getVatOnSaleLedgerId` method in the Site model to retrieve the appropriate VAT ledger for sales invoices.
- Updated Delivery and Sales controllers to log an error if the VAT ledger is not configured when there is a total tax amount.
- Adjusted accounting entry logic to use the retrieved VAT ledger ID instead of a hardcoded value, ensuring correct VAT handling in transactions.